### PR TITLE
Optimize PDF generation and improve vendor and allocation flows

### DIFF
--- a/allocation.php
+++ b/allocation.php
@@ -145,23 +145,28 @@ document.addEventListener('DOMContentLoaded', function () {
     allocationModal.addEventListener('show.bs.modal', function (event) {
         const button = event.relatedTarget;
         const batchId = button.getAttribute('data-batch-id');
-        const currentProductCode = button.getAttribute('data-product-code');
 
         // Set the batch ID in the modal title and hidden input
         modalBatchIdSpan.textContent = batchId;
         originalBatchIdInput.value = batchId;
 
-        // Reset and filter the dropdown
+        // Hide all options except placeholder until fetch completes
         targetProductSelect.value = '';
         Array.from(targetProductSelect.options).forEach(option => {
-            if (option.value) { // Don't hide the placeholder
-                if (option.getAttribute('data-product-code') === currentProductCode) {
-                    option.style.display = 'none'; // Hide the current product
-                } else {
-                    option.style.display = 'block'; // Show other products
-                }
-            }
+            if (option.value) option.style.display = 'none';
         });
+
+        // Fetch allowed target products based on unique mobile numbers
+        fetch('fetch_allocation_targets.php?batch_id=' + batchId)
+            .then(res => res.json())
+            .then(data => {
+                const allowed = data.allowed || [];
+                Array.from(targetProductSelect.options).forEach(option => {
+                    if (allowed.includes(option.value)) {
+                        option.style.display = 'block';
+                    }
+                });
+            });
     });
 });
 </script>

--- a/caller_panel.php
+++ b/caller_panel.php
@@ -177,7 +177,7 @@ const CONNECTIVITY_MAP = [ 'Y' => 'Yes', 'N' => 'No' ];
                 <label for="markedSheet" class="camera-container" id="cameraLabel">
                     <div class="form-label-icon"><i class="bi bi-camera2"></i></div><h5 class="mt-2 text-info">Tap to open Camera</h5>
                 </label>
-                <input class="form-control d-none" type="file" name="markedSheet" id="markedSheet" accept="image/*" capture="environment" required>
+                <input class="form-control d-none" type="file" name="markedSheet[]" id="markedSheet" accept="image/*" multiple required>
                 <div id="imagePreviewContainer" class="text-center mt-3"></div>
                 <div id="processing-feedback" class="alert alert-info mt-3" style="display: none;"></div>
                 <div class="d-grid gap-2 mt-4">
@@ -221,7 +221,7 @@ const CONNECTIVITY_MAP = [ 'Y' => 'Yes', 'N' => 'No' ];
         const captureForm = document.getElementById('captureForm');
         const feedbackDiv = document.getElementById('processing-feedback');
         const retakeButton = document.getElementById('retakeButton');
-        let currentImage = null;
+        let currentImages = [];
         
         startUploadBtn.addEventListener('click', () => {
             mainOptions.style.display = 'none';
@@ -230,16 +230,21 @@ const CONNECTIVITY_MAP = [ 'Y' => 'Yes', 'N' => 'No' ];
         
         markedSheetInput.addEventListener('change', (e) => {
             imagePreviewContainer.innerHTML = '';
-            const file = e.target.files[0];
-            if (file) {
-                currentImage = file;
+            currentImages = Array.from(e.target.files);
+            if (currentImages.length > 0) {
                 const reader = new FileReader();
                 reader.onload = (event) => {
                     const img = document.createElement('img');
                     img.src = event.target.result;
                     imagePreviewContainer.appendChild(img);
-                }
-                reader.readAsDataURL(file);
+                    if (currentImages.length > 1) {
+                        const info = document.createElement('div');
+                        info.textContent = `${currentImages.length} images selected`;
+                        info.classList.add('mt-2');
+                        imagePreviewContainer.appendChild(info);
+                    }
+                };
+                reader.readAsDataURL(currentImages[0]);
                 cameraLabel.style.display = 'none';
                 submitButton.disabled = false;
                 retakeButton.style.display = 'block';
@@ -256,46 +261,52 @@ const CONNECTIVITY_MAP = [ 'Y' => 'Yes', 'N' => 'No' ];
             cameraLabel.style.display = 'block';
             submitButton.disabled = true;
             retakeButton.style.display = 'none';
-            currentImage = null;
+            currentImages = [];
         });
         
         captureForm.addEventListener('submit', async (e) => {
             e.preventDefault();
-            if (!currentImage) return;
-            
+            if (currentImages.length === 0) return;
+
             submitButton.disabled = true;
             retakeButton.disabled = true;
             submitButton.innerHTML = `<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Processing with AI...`;
             feedbackDiv.style.display = 'block';
             feedbackDiv.innerHTML = '<i class="bi bi-hourglass-split me-2"></i>AI is analyzing your marked sheet...';
-            
-            const formData = new FormData();
-            formData.append('markedSheet', currentImage);
-            
-            try {
-                const response = await fetch('ajax_process_image.php', {
-                    method: 'POST',
-                    body: formData
-                });
-                const result = await response.json();
-                
-                if (result.success && result.data && result.data.length > 0) {
-                    feedbackDiv.innerHTML = '<i class="bi bi-check-circle-fill me-2"></i>AI processing complete! Review the results below.';
-                    displayResults(result.data);
-                } else {
-                    feedbackDiv.className = 'alert alert-danger mt-3';
-                    feedbackDiv.innerHTML = `<i class="bi bi-x-circle-fill me-2"></i>${result.message || 'AI could not read the marked sheet. Please ensure the image is clear and try again.'}`;
-                    submitButton.disabled = false;
-                    retakeButton.disabled = false;
-                    submitButton.innerHTML = `<i class="bi bi-magic me-2"></i>Process with AI`;
+
+            let allResults = [];
+            const processNext = async (index) => {
+                if (index >= currentImages.length) {
+                    if (allResults.length > 0) {
+                        feedbackDiv.innerHTML = '<i class="bi bi-check-circle-fill me-2"></i>AI processing complete! Review the results below.';
+                        displayResults(allResults);
+                    } else {
+                        feedbackDiv.className = 'alert alert-danger mt-3';
+                        feedbackDiv.innerHTML = '<i class="bi bi-x-circle-fill me-2"></i>AI could not read the marked sheets. Please ensure the images are clear and try again.';
+                        submitButton.disabled = false;
+                        retakeButton.disabled = false;
+                        submitButton.innerHTML = `<i class="bi bi-magic me-2"></i>Process with AI`;
+                    }
+                    return;
                 }
-            } catch (error) {
-                feedbackDiv.className = 'alert alert-danger mt-3';
-                feedbackDiv.innerHTML = '<i class="bi bi-wifi-off me-2"></i>Network error occurred. Please check your connection and try again.';
-                submitButton.disabled = false;
-                retakeButton.disabled = false;
-                submitButton.innerHTML = `<i class="bi bi-magic me-2"></i>Process with AI`;
-            }
+
+                const formData = new FormData();
+                formData.append('markedSheet', currentImages[index]);
+
+                try {
+                    const response = await fetch('ajax_process_image.php', { method: 'POST', body: formData });
+                    const result = await response.json();
+                    if (result.success && result.data && result.data.length > 0) {
+                        allResults = allResults.concat(result.data);
+                    }
+                } catch (err) {
+                    // ignore individual image errors
+                }
+
+                processNext(index + 1);
+            };
+
+            processNext(0);
         });
         function displayResults(results) {
             const tbody = document.getElementById('results-tbody');

--- a/db_config.php
+++ b/db_config.php
@@ -81,21 +81,23 @@ function generateAdminId($name, $conn) {
 }
 
 /**
- * Generates the next globally unique vendor ID (e.g., V01, V02, V10).
- * This logic remains global as vendor IDs are unique system-wide.
+ * Generates the next globally unique vendor ID (e.g., V01, V02, V61).
+ * Optional $minNumber allows starting the sequence from a specific number
+ * (used for additional vendor requests starting from V61).
  */
-function generateVendorId($conn) {
-    $stmt = $conn->prepare("SELECT vendor_id FROM vendors ORDER BY CAST(SUBSTRING(vendor_id, 2) AS UNSIGNED) DESC LIMIT 1");
+function generateVendorId($conn, $minNumber = 1) {
+    $stmt = $conn->prepare("SELECT vendor_id FROM vendors WHERE CAST(SUBSTRING(vendor_id, 2) AS UNSIGNED) >= ? ORDER BY CAST(SUBSTRING(vendor_id, 2) AS UNSIGNED) DESC LIMIT 1");
+    $stmt->bind_param("i", $minNumber);
     $stmt->execute();
     $result = $stmt->get_result();
-    
+
     if ($result->num_rows > 0) {
         $lastId = $result->fetch_assoc()['vendor_id'];
         $number = intval(substr($lastId, 1)) + 1;
     } else {
-        $number = 1;
+        $number = $minNumber;
     }
-    
+
     $stmt->close();
     return 'V' . str_pad($number, 2, '0', STR_PAD_LEFT);
 }

--- a/fetch_allocation_targets.php
+++ b/fetch_allocation_targets.php
@@ -1,0 +1,53 @@
+<?php
+require_once 'db_config.php';
+requireAdmin();
+
+header('Content-Type: application/json');
+
+$batchId = $_GET['batch_id'] ?? '';
+if (!$batchId) {
+    echo json_encode(['allowed' => []]);
+    exit();
+}
+
+$conn = getDBConnection();
+
+// Total distinct mobiles in the batch
+$totalStmt = $conn->prepare("SELECT COUNT(DISTINCT mobile_no) as total FROM final_call_logs WHERE batch_id = ?");
+$totalStmt->bind_param("s", $batchId);
+$totalStmt->execute();
+$total = $totalStmt->get_result()->fetch_assoc()['total'] ?? 0;
+$totalStmt->close();
+
+if ($total == 0) {
+    $conn->close();
+    echo json_encode(['allowed' => []]);
+    exit();
+}
+
+// Current product code of the batch
+$prodStmt = $conn->prepare("SELECT product_code FROM file_batches WHERE id = ?");
+$prodStmt->bind_param("s", $batchId);
+$prodStmt->execute();
+$currentProduct = $prodStmt->get_result()->fetch_assoc()['product_code'] ?? '';
+$prodStmt->close();
+
+$allowed = [];
+$products = $conn->prepare("SELECT id, product_code FROM products WHERE is_active = 1 AND product_code != ?");
+$products->bind_param("s", $currentProduct);
+$products->execute();
+$res = $products->get_result();
+while ($prod = $res->fetch_assoc()) {
+    $dupStmt = $conn->prepare("SELECT COUNT(DISTINCT fl.mobile_no) as cnt FROM final_call_logs fl JOIN file_batches fb ON fl.batch_id = fb.id WHERE fb.product_code = ? AND fl.mobile_no IN (SELECT mobile_no FROM final_call_logs WHERE batch_id = ?)");
+    $dupStmt->bind_param("ss", $prod['product_code'], $batchId);
+    $dupStmt->execute();
+    $dup = $dupStmt->get_result()->fetch_assoc()['cnt'] ?? 0;
+    $dupStmt->close();
+    if (($total - $dup) > 0) {
+        $allowed[] = (string)$prod['id'];
+    }
+}
+$products->close();
+$conn->close();
+
+echo json_encode(['allowed' => $allowed]);

--- a/generate_pdf.php
+++ b/generate_pdf.php
@@ -63,7 +63,8 @@ $fullBaseSql = $baseSql . $whereSql;
 
 // Define columns in the order they should appear (excluding status)
 // Fixed order: id, slot, connectivity, disposition, then dynamic columns
-$optionalColumns = ['name', 'mobile_no', 'title', 'policy_number', 'pan', 'dob', 'age', 'expiry', 'address', 'city', 'state', 'country', 'pincode', 'plan', 'premium', 'sum_insured'];
+// Mobile number now comes before name as per new requirement
+$optionalColumns = ['mobile_no', 'name', 'title', 'policy_number', 'pan', 'dob', 'age', 'expiry', 'address', 'city', 'state', 'country', 'pincode', 'plan', 'premium', 'sum_insured'];
 $selects = [];
 foreach ($optionalColumns as $column) {
     $selects[] = "MAX(CASE WHEN `{$column}` IS NOT NULL AND `{$column}` != '' THEN 1 ELSE 0 END) as has_{$column}";
@@ -85,9 +86,11 @@ $stmt->close();
 $finalHeaders = ['id', 'slot', 'connectivity', 'disposition'];
 
 // Add optional columns that have data, in the correct order
+// Ensure the table does not exceed 12 columns in total
 foreach ($optionalColumns as $column) {
     if (!empty($columnPresence["has_{$column}"])) {
         $finalHeaders[] = $column;
+        if (count($finalHeaders) >= 12) break;
     }
 }
 
@@ -101,9 +104,11 @@ $mpdf->SetTitle($pdfTitle);
 $dispResult = $conn->query("SELECT code, description, category FROM disposition_codes WHERE is_active = 1 ORDER BY category, code");
 $dispLegendY = "<strong>DISPO (Y):</strong>";
 $dispLegendN = "<strong>DISPO (N):</strong>";
+$dispCodes = [];
 while($d = $dispResult->fetch_assoc()){
     if($d['category'] == 'connected') $dispLegendY .= " {$d['code']}:{$d['description']} |";
     else $dispLegendN .= " {$d['code']}:{$d['description']} |";
+    $dispCodes[] = $d['code'];
 }
 $dispLegend = rtrim($dispLegendY, ' |') . ' || ' . rtrim($dispLegendN, ' |');
 $slotLegend = "<strong>SLOTS:</strong> 1 (10-11a) | 2 (11a-12p) | 3 (12-1p) | 4 (1-2p) | 5 (2-3p) | 6 (3-4p) | 7 (4-5p) | 8 (5-6p)";
@@ -116,14 +121,14 @@ $html_head = '<html><head><style>
     tr { page-break-inside: avoid; page-break-after: auto; }
     th, td { border: 1px solid #333; padding: 3px; text-align: left; vertical-align: middle; word-wrap: break-word; }
     thead th, .legend-cell { text-align: center; font-weight: bold; background-color: #f2f2f2; }
-    td:nth-child(6) { position: relative; font-weight: bold; font-family: monospace;} /* Mobile column is 6th */
+    td:nth-child(5) { position: relative; font-weight: bold; font-family: monospace;} /* Mobile column is 5th */
     .id-col { font-size: 6.5pt; font-family: monospace; }
     .scissor-line { position: absolute; top: 0; bottom: 0; left: 50%; border-left: 1px dashed #000; width: 1px; height: 100%; }
     .scissor-icon { position: absolute; top: -8px; left: 45%; font-size: 10pt; }
     .connectivity-col, .slot-cell { text-align: center; }
     .disposition-cell { font-size: 7pt; padding: 1px !important; }
     .dispo-grid { border: none !important; width: 100%; table-layout: fixed; }
-    .dispo-grid td { border: none !important; padding: 1px 2px; text-align: left; }
+    .dispo-grid td { border: none !important; padding: 1px 2px; text-align: left; white-space: nowrap; }
 </style></head><body>';
 
 // Create Table Header Row
@@ -207,7 +212,16 @@ while (true) {
             $cellContent = '';
             switch($header) {
                 case 'disposition':
-                    $cellContent = '<table class="dispo-grid"><tr><td>○ 11</td><td>○ 12</td><td>○ 13</td><td>○ 14</td><td>○ 15</td><td>○ 16</td><td>○ 17</td></tr><tr><td>○ 21</td><td>○ 22</td><td>○ 23</td><td>○ 24</td><td>○ 25</td><td>○ 26</td><td></td></tr></table>';
+                    $cellContent = '<table class="dispo-grid"><tr>';
+                    $codeCounter = 0;
+                    foreach ($dispCodes as $code) {
+                        if ($codeCounter > 0 && $codeCounter % 7 == 0) {
+                            $cellContent .= '</tr><tr>';
+                        }
+                        $cellContent .= '<td>○ ' . htmlspecialchars($code) . '</td>';
+                        $codeCounter++;
+                    }
+                    $cellContent .= '</tr></table>';
                     $class = 'disposition-cell';
                     break;
                 case 'connectivity':

--- a/manage_admins.php
+++ b/manage_admins.php
@@ -6,6 +6,82 @@ $conn = getDBConnection();
 $message = '';
 $error = '';
 
+// Helper to insert caller and map to admin
+function insertCallerAndMap($finqyId, $name, $mobile, $type, $adminId, $conn, &$count) {
+    $callerStmt = $conn->prepare("INSERT INTO callers (finqy_id, caller_name, mobile_no, caller_type, is_active) VALUES (?, ?, ?, ?, 1) ON DUPLICATE KEY UPDATE caller_name = VALUES(caller_name), mobile_no = VALUES(mobile_no)");
+    $callerStmt->bind_param("ssss", $finqyId, $name, $mobile, $type);
+    $callerStmt->execute();
+    $callerStmt->close();
+
+    $mapStmt = $conn->prepare("INSERT INTO admin_caller_mapping (admin_id, finqy_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE admin_id = VALUES(admin_id)");
+    $mapStmt->bind_param("ss", $adminId, $finqyId);
+    $mapStmt->execute();
+    $mapStmt->close();
+    $count++;
+}
+
+// Map partner -> connector -> team hierarchy for a given partner record
+function mapPartnerTree($partner, $adminId, $conn, &$count) {
+    insertCallerAndMap($partner['refercode'], $partner['name'], $partner['mobile'], 'partner', $adminId, $conn, $count);
+
+    $connectorStmt = $conn->prepare("SELECT id, refercode, rname as name, mobile_no as mobile FROM corporate_connector WHERE master_refercode = ?");
+    $connectorStmt->bind_param("s", $partner['refercode']);
+    $connectorStmt->execute();
+    $connectors = $connectorStmt->get_result();
+    while ($connector = $connectors->fetch_assoc()) {
+        insertCallerAndMap($connector['refercode'], $connector['name'], $connector['mobile'], 'connector', $adminId, $conn, $count);
+
+        $teamStmt = $conn->prepare("SELECT id, refercode, username as name, mobile FROM corp_leader WHERE leader_of = ?");
+        $teamStmt->bind_param("s", $connector['refercode']);
+        $teamStmt->execute();
+        $teams = $teamStmt->get_result();
+        while ($team = $teams->fetch_assoc()) {
+            insertCallerAndMap($team['refercode'], $team['name'], $team['mobile'], 'team', $adminId, $conn, $count);
+        }
+        $teamStmt->close();
+    }
+    $connectorStmt->close();
+}
+
+// Recursively map all partners/connectors/teams under a corporate user
+function mapUserHierarchy($user, $adminId, $conn, &$count) {
+    // Map partners directly added by this user
+    $partnerStmt = $conn->prepare("SELECT id, refercode, rname as name, mobile_no as mobile FROM first_register WHERE addedBy = ?");
+    $partnerStmt->bind_param("i", $user['id']);
+    $partnerStmt->execute();
+    $partners = $partnerStmt->get_result();
+    while ($partner = $partners->fetch_assoc()) {
+        mapPartnerTree($partner, $adminId, $conn, $count);
+    }
+    $partnerStmt->close();
+
+    // Fetch subordinates based on designation
+    $username = $user['username'];
+    $designation = $user['designation'];
+
+    if ($designation == 'zonal_manager') {
+        $bmStmt = $conn->prepare("SELECT id, username, designation FROM corporate_user_permission WHERE zm_allocated = ? AND designation = 'branch_manager'");
+        $bmStmt->bind_param("s", $username);
+        $bmStmt->execute();
+        $bms = $bmStmt->get_result();
+        while ($bm = $bms->fetch_assoc()) {
+            mapUserHierarchy($bm, $adminId, $conn, $count);
+        }
+        $bmStmt->close();
+    }
+
+    if (in_array($designation, ['zonal_manager', 'branch_manager'])) {
+        $admStmt = $conn->prepare("SELECT id, username, designation FROM corporate_user_permission WHERE bm_allocated = ? AND designation = 'agency_development_manager'");
+        $admStmt->bind_param("s", $username);
+        $admStmt->execute();
+        $adms = $admStmt->get_result();
+        while ($adm = $adms->fetch_assoc()) {
+            mapUserHierarchy($adm, $adminId, $conn, $count);
+        }
+        $admStmt->close();
+    }
+}
+
 // Handle admin creation with hierarchical mapping
 if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
     if ($_POST['action'] == 'create_admin') {
@@ -60,138 +136,10 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
                         $vendorStmt->close();
                     }
                     
-                    // Now map partners, connectors, and teams as callers
+                    // Map entire hierarchy of callers under this corporate user
                     $callerCount = 0;
-                    
-                    // 1. Find all partners connected to this admin (ADM/BM/ZM)
-                    $partnerStmt = $conn->prepare("
-                        SELECT id, refercode, rname as name, mobile_no as mobile 
-                        FROM first_register 
-                        WHERE addedBy = ?
-                    ");
-                    if ($partnerStmt === false) {
-                        throw new Exception("Failed to prepare partner query: " . $conn->error);
-                    }
-                    $partnerStmt->bind_param("i", $corpUserId);
-                    $partnerStmt->execute();
-                    $partners = $partnerStmt->get_result();
-                    
-                    while ($partner = $partners->fetch_assoc()) {
-                        // Insert partner as caller
-                        $callerStmt = $conn->prepare("
-                            INSERT INTO callers (finqy_id, caller_name, mobile_no, caller_type, is_active) 
-                            VALUES (?, ?, ?, 'partner', 1)
-                            ON DUPLICATE KEY UPDATE caller_name = VALUES(caller_name), mobile_no = VALUES(mobile_no)
-                        ");
-                        if ($callerStmt === false) {
-                            throw new Exception("Failed to prepare caller insert: " . $conn->error);
-                        }
-                        $finqyId = $partner['refercode'];
-                        $callerName = $partner['name'];
-                        $mobileNo = $partner['mobile'];
-                        $callerStmt->bind_param("sss", $finqyId, $callerName, $mobileNo);
-                        $callerStmt->execute();
-                        $callerStmt->close();
-                        
-                        // Map to admin
-                        $mapStmt = $conn->prepare("
-                            INSERT INTO admin_caller_mapping (admin_id, finqy_id) 
-                            VALUES (?, ?)
-                            ON DUPLICATE KEY UPDATE admin_id = VALUES(admin_id)
-                        ");
-                        $mapStmt->bind_param("ss", $adminId, $finqyId);
-                        $mapStmt->execute();
-                        $mapStmt->close();
-                        $callerCount++;
-                        
-                        // 2. Find all connectors connected to this partner
-                        $connectorStmt = $conn->prepare("
-                            SELECT id, refercode, rname as name, mobile_no as mobile 
-                            FROM corporate_connector 
-                            WHERE master_refercode = ?
-                        ");
-                        if ($connectorStmt === false) {
-                            throw new Exception("Failed to prepare connector query: " . $conn->error);
-                        }
-                        $connectorStmt->bind_param("s", $partner['refercode']);
-                        $connectorStmt->execute();
-                        $connectors = $connectorStmt->get_result();
-                        
-                        while ($connector = $connectors->fetch_assoc()) {
-                            // Insert connector as caller
-                            $callerStmt = $conn->prepare("
-                                INSERT INTO callers (finqy_id, caller_name, mobile_no, caller_type, is_active) 
-                                VALUES (?, ?, ?, 'connector', 1)
-                                ON DUPLICATE KEY UPDATE caller_name = VALUES(caller_name), mobile_no = VALUES(mobile_no)
-                            ");
-                            if ($callerStmt === false) {
-                                throw new Exception("Failed to prepare connector caller insert: " . $conn->error);
-                            }
-                            $finqyId = $connector['refercode'];
-                            $callerName = $connector['name'];
-                            $mobileNo = $connector['mobile'];
-                            $callerStmt->bind_param("sss", $finqyId, $callerName, $mobileNo);
-                            $callerStmt->execute();
-                            $callerStmt->close();
-                            
-                            // Map to admin
-                            $mapStmt = $conn->prepare("
-                                INSERT INTO admin_caller_mapping (admin_id, finqy_id) 
-                                VALUES (?, ?)
-                                ON DUPLICATE KEY UPDATE admin_id = VALUES(admin_id)
-                            ");
-                            $mapStmt->bind_param("ss", $adminId, $finqyId);
-                            $mapStmt->execute();
-                            $mapStmt->close();
-                            $callerCount++;
-                            
-                            // 3. Find all teams connected to this connector
-                            $teamStmt = $conn->prepare("
-                                SELECT id, refercode, username as name, mobile 
-                                FROM corp_leader 
-                                WHERE leader_of = ?
-                            ");
-                            if ($teamStmt === false) {
-                                throw new Exception("Failed to prepare team query: " . $conn->error);
-                            }
-                            $teamStmt->bind_param("s", $connector['refercode']);
-                            $teamStmt->execute();
-                            $teams = $teamStmt->get_result();
-                            
-                            while ($team = $teams->fetch_assoc()) {
-                                // Insert team member as caller
-                                $callerStmt = $conn->prepare("
-                                    INSERT INTO callers (finqy_id, caller_name, mobile_no, caller_type, is_active) 
-                                    VALUES (?, ?, ?, 'team', 1)
-                                    ON DUPLICATE KEY UPDATE caller_name = VALUES(caller_name), mobile_no = VALUES(mobile_no)
-                                ");
-                                if ($callerStmt === false) {
-                                    throw new Exception("Failed to prepare team caller insert: " . $conn->error);
-                                }
-                                $finqyId = $team['refercode'];
-                                $callerName = $team['name'];
-                                $mobileNo = $team['mobile'];
-                                $callerStmt->bind_param("sss", $finqyId, $callerName, $mobileNo);
-                                $callerStmt->execute();
-                                $callerStmt->close();
-                                
-                                // Map to admin
-                                $mapStmt = $conn->prepare("
-                                    INSERT INTO admin_caller_mapping (admin_id, finqy_id) 
-                                    VALUES (?, ?)
-                                    ON DUPLICATE KEY UPDATE admin_id = VALUES(admin_id)
-                                ");
-                                $mapStmt->bind_param("ss", $adminId, $finqyId);
-                                $mapStmt->execute();
-                                $mapStmt->close();
-                                $callerCount++;
-                            }
-                            $teamStmt->close();
-                        }
-                        $connectorStmt->close();
-                    }
-                    $partnerStmt->close();
-                    
+                    mapUserHierarchy($corpUser, $adminId, $conn, $callerCount);
+
                     $conn->commit();
                     $message = "Admin user created successfully with ID: $adminId, 5 default vendors, and $callerCount callers mapped from hierarchy.";
                 } catch (Exception $e) {

--- a/process_allocation.php
+++ b/process_allocation.php
@@ -43,7 +43,7 @@ try {
     $new_batch_id = generateBatchId($targetProductCode, $vendorId, $adminId, $conn);
 
     // 4. Insert the new batch record
-    $stmt = $conn->prepare("INSERT INTO file_batches (id, admin_id, vendor_id, product_code, original_batch_id, original_filename) 
+    $stmt = $conn->prepare("INSERT INTO file_batches (id, admin_id, vendor_id, product_code, original_batch_id, original_filename)
                            SELECT ?, ?, ?, ?, ?, CONCAT('Allocated from ', ?) FROM file_batches WHERE id = ?");
     $stmt->bind_param("sssssss", $new_batch_id, $adminId, $vendorId, $targetProductCode, $original_batch_id, $original_batch_id, $original_batch_id);
     $stmt->execute();
@@ -56,28 +56,47 @@ try {
     $original_logs = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
     $stmt->close();
 
-    // 6. Prepare the statement for inserting new log records
-    $insert_log_sql = "INSERT INTO final_call_logs (id, batch_id, mobile_no, title, name, policy_number, pan, dob, age, expiry, address, city, state, country, pincode, plan, premium, sum_insured, status, extra_data) 
+    // Existing mobile numbers for the target product
+    $stmt = $conn->prepare("SELECT fl.mobile_no FROM final_call_logs fl JOIN file_batches fb ON fl.batch_id = fb.id WHERE fb.product_code = ?");
+    $stmt->bind_param("s", $targetProductCode);
+    $stmt->execute();
+    $existing = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+    $existingMobiles = [];
+    foreach ($existing as $row) { $existingMobiles[$row['mobile_no']] = true; }
+
+    // 6. Prepare insert statement
+    $insert_log_sql = "INSERT INTO final_call_logs (id, batch_id, mobile_no, title, name, policy_number, pan, dob, age, expiry, address, city, state, country, pincode, plan, premium, sum_insured, status, extra_data)
                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     $insert_stmt = $conn->prepare($insert_log_sql);
 
     $rowCounter = 1;
+    $insertedCount = 0;
     foreach ($original_logs as $log) {
+        if (isset($existingMobiles[$log['mobile_no']])) {
+            continue;
+        }
+        $existingMobiles[$log['mobile_no']] = true;
         $new_log_id = generateLogRowId($new_batch_id, $rowCounter);
-        
-        $insert_stmt->bind_param("sssssssssissssssssss", 
-            $new_log_id, $new_batch_id, $log['mobile_no'], $log['title'], $log['name'], 
-            $log['policy_number'], $log['pan'], $log['dob'], $log['age'], $log['expiry'], 
-            $log['address'], $log['city'], $log['state'], $log['country'], $log['pincode'], 
+
+        $insert_stmt->bind_param("sssssssssissssssssss",
+            $new_log_id, $new_batch_id, $log['mobile_no'], $log['title'], $log['name'],
+            $log['policy_number'], $log['pan'], $log['dob'], $log['age'], $log['expiry'],
+            $log['address'], $log['city'], $log['state'], $log['country'], $log['pincode'],
             $log['plan'], $log['premium'], $log['sum_insured'], $log['status'], $log['extra_data']
         );
         $insert_stmt->execute();
         $rowCounter++;
+        $insertedCount++;
     }
     $insert_stmt->close();
 
+    if ($insertedCount == 0) {
+        throw new Exception("No unique entries found for allocation.");
+    }
+
     $conn->commit();
-    $_SESSION['flash_message'] = ['type' => 'success', 'text' => "Successfully allocated batch {$original_batch_id} to new batch {$new_batch_id}."];
+    $_SESSION['flash_message'] = ['type' => 'success', 'text' => "Successfully allocated batch {$original_batch_id} to new batch {$new_batch_id} with {$insertedCount} unique records."];
 
 } catch (Exception $e) {
     $conn->rollback();
@@ -87,3 +106,4 @@ try {
     header("Location: allocation.php");
     exit();
 }
+?>

--- a/request_vendor.php
+++ b/request_vendor.php
@@ -12,15 +12,28 @@ $vendorName = trim($_POST['vendor_name']);
 
 if (empty($vendorName)) {
     $_SESSION['flash_message'] = ['type' => 'danger', 'text' => 'Vendor name cannot be empty.'];
-    header("Location: admin_panel.php");
+    header("Location: upload_batch.php");
     exit();
 }
 
 $conn = getDBConnection();
 
+// Ensure admin has not exceeded maximum of 4 requests
+$countStmt = $conn->prepare("SELECT COUNT(*) as total FROM vendor_requests WHERE admin_id = ?");
+$countStmt->bind_param("s", $adminId);
+$countStmt->execute();
+$totalRequests = $countStmt->get_result()->fetch_assoc()['total'];
+$countStmt->close();
+
+if ($totalRequests >= 4) {
+    $_SESSION['flash_message'] = ['type' => 'warning', 'text' => 'You have reached the maximum number of vendor requests (4).'];
+    header("Location: upload_batch.php");
+    exit();
+}
+
 // Check if a similar request is already pending
 $checkStmt = $conn->prepare("
-    SELECT id FROM vendor_requests 
+    SELECT id FROM vendor_requests
     WHERE admin_id = ? AND vendor_name = ? AND status = 'pending'
 ");
 $checkStmt->bind_param("ss", $adminId, $vendorName);
@@ -48,5 +61,5 @@ if ($result->num_rows > 0) {
 $checkStmt->close();
 $conn->close();
 
-header("Location: admin_panel.php");
+header("Location: upload_batch.php");
 exit();

--- a/upload_batch.php
+++ b/upload_batch.php
@@ -260,7 +260,10 @@ function formatDateString($value): string {
                         <form action="upload_batch.php" method="post" enctype="multipart/form-data" id="upload-form">
                             <div class="row g-3">
                                 <div class="col-md-6">
-                                    <label for="vendor_id" class="form-label"><strong>Select Vendor</strong></label>
+                                    <label for="vendor_id" class="form-label d-flex justify-content-between align-items-center">
+                                        <strong>Select Vendor</strong>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" id="addVendorBtn" title="Request New Vendor"><i class="bi bi-plus"></i></button>
+                                    </label>
                                     <select class="form-select" id="vendor_id" name="vendor_id" required>
                                         <option value="">-- Select a Vendor --</option>
                                         <?php while($row = $vendors->fetch_assoc()): ?>
@@ -289,6 +292,31 @@ function formatDateString($value): string {
             </main>
         </div>
     </div>
+
+<!-- Vendor Request Modal -->
+<div class="modal fade" id="vendorRequestModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form action="request_vendor.php" method="POST">
+                <div class="modal-header">
+                    <h5 class="modal-title">Request New Vendor</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Vendor Name</label>
+                        <input type="text" class="form-control" name="vendor_name" required>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <script>
     document.getElementById('upload-form').addEventListener('submit', function() {
         if (document.getElementById('customerFile').files.length > 0) {
@@ -328,6 +356,15 @@ function formatDateString($value): string {
             alert('Please select a disposition status from the dropdown.');
         }
     });
+
+    // Show vendor request modal
+    const addVendorBtn = document.getElementById('addVendorBtn');
+    if (addVendorBtn) {
+        addVendorBtn.addEventListener('click', () => {
+            const modal = new bootstrap.Modal(document.getElementById('vendorRequestModal'));
+            modal.show();
+        });
+    }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/vendor_requests.php
+++ b/vendor_requests.php
@@ -24,8 +24,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['action'])) {
             $conn->begin_transaction();
             try {
                 if ($action == 'approve') {
-                    // Generate vendor ID
-                    $vendorId = generateVendorId($request['admin_id'], $conn);
+                    // Generate vendor ID starting from V61 for requested vendors
+                    $vendorId = generateVendorId($conn, 61);
                     
                     // Create vendor
                     $vendorStmt = $conn->prepare("INSERT INTO vendors (vendor_id, vendor_name, admin_id, is_approved) VALUES (?, ?, ?, 1)");


### PR DESCRIPTION
## Summary
- Reordered PDF headers so mobile numbers precede names, capped total columns at 12 and generated disposition grids dynamically.
- Added vendor request modal with request limits and unique IDs starting from V61.
- Extended admin creation to map entire partner/connector/team hierarchy and enabled callers to process multiple photos sequentially.
- Skipped duplicate mobiles during batch allocation and hid target products without unique records.

## Testing
- `php -l generate_pdf.php`
- `php -l request_vendor.php`
- `php -l vendor_requests.php`
- `php -l db_config.php`
- `php -l upload_batch.php`
- `php -l manage_admins.php`
- `php -l caller_panel.php`
- `php -l allocation.php`
- `php -l fetch_allocation_targets.php`
- `php -l process_allocation.php`


------
https://chatgpt.com/codex/tasks/task_e_6895dc0447048330afe98ffa9ebbedb3