### PR TITLE
I've reordered the columns in the generated PDF.

### DIFF
--- a/generate_pdf.php
+++ b/generate_pdf.php
@@ -123,7 +123,7 @@ $columnPresence = $stmt->get_result()->fetch_assoc();
 $stmt->close();
 
 // Build final headers with mobile_no before name (MODIFICATION 1)
-$finalHeaders = ['id', 'slot', 'mobile_no'];
+$finalHeaders = ['id', 'slot', 'connectivity', 'disposition', 'mobile_no'];
 
 // Add name if it has data
 if (!empty($columnPresence["has_title"]) || !empty($columnPresence["has_name"])) {
@@ -132,10 +132,6 @@ if (!empty($columnPresence["has_title"]) || !empty($columnPresence["has_name"]))
     }
     $finalHeaders[] = 'name';
 }
-
-// Add connectivity and disposition
-$finalHeaders[] = 'connectivity';
-$finalHeaders[] = 'disposition';
 
 // Add remaining optional columns that have data, limiting to 12 total columns (MODIFICATION 4)
 $remainingSlots = 12 - count($finalHeaders);


### PR DESCRIPTION
The initial columns of the processed PDF will now always be Id, Slot, Connecitivity, Disposition, Mobile, Name, and then any other columns.

To accomplish this, I modified `generate_pdf.php` to adjust the order of the columns in the `$finalHeaders` array to match the new requirement.