### PR TITLE
Ensure telecaller dashboard uses real data

### DIFF
--- a/caller_panel.php
+++ b/caller_panel.php
@@ -161,7 +161,7 @@ const CONNECTIVITY_MAP = [ 'Y' => 'Yes', 'N' => 'No' ];
                 <div class="card-body p-4 d-flex flex-column justify-content-center">
                     <h3 class="card-title"><i class="bi bi-bar-chart-line-fill fs-1 text-success"></i><br>View Performance</h3>
                     <p class="text-muted mt-2">Check your call statistics and recent activity.</p>
-                    <a href="telecaller_dashboard.php" class="btn btn-success mt-auto">View All Logs</a>
+                    <a href='telecaller_dashboard.php?finqy_id=<?= urlencode($_SESSION['finqy_id']) ?>' class='btn btn-success mt-auto'>View Dashboard</a>
                 </div>
             </div>
         </div>

--- a/telecaller_dashboard.php
+++ b/telecaller_dashboard.php
@@ -76,8 +76,8 @@ $slot_query = "
         ROUND((SUM(CASE WHEN disposition IN ('Interested', 'Call Back', 'More Info') THEN 1 ELSE 0 END) * 100.0 / COUNT(*)), 2) as conversion_rate
     FROM final_call_logs fcl 
     $where_clause AND fcl.processed_at IS NOT NULL AND slot IS NOT NULL
-    GROUP BY slot 
-    ORDER BY slot
+    GROUP BY slot
+    ORDER BY CAST(slot AS UNSIGNED)
 ";
 
 $stmt = $conn->prepare($slot_query);


### PR DESCRIPTION
## Summary
- Link caller panel to telecaller dashboard with encoded finqy ID so the dashboard loads real database metrics for that user
- Sort time-slot analysis numerically in telecaller dashboard for accurate data visualization

## Testing
- `php -l caller_panel.php`
- `php -l telecaller_dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_689c5d9ff01c833080e6fabebfdd2fc4